### PR TITLE
remove unused and broken import statements

### DIFF
--- a/Mining/src/main/java/com/nest/ib/vo/OfferTask.java
+++ b/Mining/src/main/java/com/nest/ib/vo/OfferTask.java
@@ -3,14 +3,12 @@ package com.nest.ib.vo;
 import com.nest.ib.service.MiningService;
 
 import com.nest.ib.utils.EthClient;
-import com.sun.org.apache.regexp.internal.RE;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
-import sun.security.krb5.Credentials;
 
 /**
  * ClassName:applicationBonusStorage


### PR DESCRIPTION
import com.sun.org.apache.regexp.internal.RE causes a compilation error when running ibApplication & is unused anyway

import sun.security.krb5.Credentials; is not used 

